### PR TITLE
feat: show place details in speech bubble

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -72,22 +72,46 @@ html, body { margin:0; padding:0; height:100%; }
 }
 .place-item:hover { background: #f0f0f0; }
 
-#placeDetail {
-  display: none;
-  margin-top: 8px;
+/* Popup links von der Sidebar für Ortsdetails */
+.place-popup {
+  position: fixed;
+  max-width: 240px;
   background: #fff;
   border: 1px solid #ddd;
+  border-radius: 6px;
   padding: 10px 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,.15);
+  z-index: 1001;
+  transform: translateY(-50%);
 }
-
-#placesContainer.open #placeDetail {
-  display: block;
+.place-popup::before,
+.place-popup::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0;
+  height: 0;
 }
-
-#placeDetail h4 {
+.place-popup::before {
+  right: -13px;
+  border-top: 9px solid transparent;
+  border-bottom: 9px solid transparent;
+  border-left: 13px solid #ddd;
+}
+.place-popup::after {
+  right: -12px;
+  border-top: 8px solid transparent;
+  border-bottom: 8px solid transparent;
+  border-left: 12px solid #fff;
+}
+.place-popup.hidden {
+  display: none;
+}
+.place-popup h4 {
   margin: 0 0 6px;
   font-size: 16px;
 }
-#placeDetail p {
+.place-popup p {
   margin: 0;
 }

--- a/index.html
+++ b/index.html
@@ -23,9 +23,10 @@
   <div id="sidebarContent"></div>
   <div id="placesContainer" class="places-container">
     <div id="placeList" class="place-list"></div>
-    <div id="placeDetail" class="place-detail"></div>
   </div>
 </div>
+
+  <div id="placePopup" class="place-popup hidden"></div>
 
 
   <!-- Leaflet JS -->

--- a/js/script.js
+++ b/js/script.js
@@ -62,10 +62,13 @@ const sidebarContent = document.getElementById('sidebarContent');
 const sidebarClose = document.getElementById('sidebarClose');
 const placesContainer = document.getElementById('placesContainer');
 const placeList = document.getElementById('placeList');
-const placeDetail = document.getElementById('placeDetail');
+const placePopup = document.getElementById('placePopup');
 
 placesContainer?.addEventListener('click', ev => ev.stopPropagation());
-document.addEventListener('click', () => placesContainer?.classList.remove('open'));
+placePopup?.addEventListener('click', ev => ev.stopPropagation());
+document.addEventListener('click', () => {
+  placePopup?.classList.add('hidden');
+});
 
 function openSidebar(props) {
   const name = props?.name ?? 'Unbenannte Nation';
@@ -77,10 +80,10 @@ function openSidebar(props) {
     ${descLong ? `<div class="long">${descLong}</div>` : '<p><i>Keine längere Beschreibung gespeichert.</i></p>'}
   `;
 
-  if (placesContainer && placeList && placeDetail) {
+  placePopup?.classList.add('hidden');
+
+  if (placesContainer && placeList) {
     placeList.innerHTML = '';
-    placeDetail.innerHTML = '';
-    placesContainer.classList.remove('open');
     placesContainer.style.display = places.length ? '' : 'none';
 
     places.forEach(p => {
@@ -90,8 +93,14 @@ function openSidebar(props) {
       item.title = p.short ?? '';
       item.addEventListener('click', ev => {
         ev.stopPropagation();
-        placeDetail.innerHTML = `<h4>${p.name}</h4><p>${p.long ?? ''}</p>`;
-        placesContainer.classList.add('open');
+        if (placePopup && sidebar) {
+          placePopup.innerHTML = `<h4>${p.name}</h4><p>${p.long ?? ''}</p>`;
+          const itemRect = item.getBoundingClientRect();
+          const sidebarRect = sidebar.getBoundingClientRect();
+          placePopup.style.top = (itemRect.top + itemRect.height / 2) + 'px';
+          placePopup.style.right = (window.innerWidth - sidebarRect.left + 10) + 'px';
+          placePopup.classList.remove('hidden');
+        }
       });
       placeList.appendChild(item);
     });
@@ -103,6 +112,7 @@ function openSidebar(props) {
 sidebarClose?.addEventListener('click', () => {
   sidebar.classList.remove('open');
   sidebar.classList.add('hidden');
+  placePopup?.classList.add('hidden');
 });
 
 // Helper: lädt eine Datei (GeoJSON)


### PR DESCRIPTION
## Summary
- display place details in a speech bubble popup to the left of the sidebar
- add styling for bubble with arrow pointing to place list
- hide popup when clicking elsewhere or closing sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b406ae35dc83309082f7ca38827f69