### PR TITLE
Move places sidebar left and add customizable header

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -2,6 +2,30 @@ html, body { margin:0; padding:0; height:100%; }
 #map { width:100%; height:100vh; }
 .leaflet-interactive { cursor:pointer; }
 
+/* Seitenkopf mit optionalem Hintergrundbild und Wappen */
+#titleBanner {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 6px 10px;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background-size: cover;
+  background-position: center;
+}
+#titleBanner .title-text {
+  font-size: 24px;
+  line-height: 1;
+}
+#cityIcon {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+}
+
 /* Optional: kleiner Reset-Button (falls später genutzt) */
 .map-reset {
   background:#fff; border:1px solid #bbb; border-radius:4px;
@@ -9,24 +33,24 @@ html, body { margin:0; padding:0; height:100%; }
 }
 .map-reset:hover { background:#f3f3f3; }
 
-/* Seitenleiste rechts */
+/* Seitenleiste links */
 .sidebar {
   position: fixed;
   top: 0;
-  right: 0;
+  left: 0;
   width: 360px;
   max-width: 90vw;
   height: 100vh;
   background: #ffffff;
-  box-shadow: -4px 0 18px rgba(0,0,0,.15);
+  box-shadow: 4px 0 18px rgba(0,0,0,.15);
   padding: 16px 14px 24px;
   overflow: auto;
-  transform: translateX(100%);
+  transform: translateX(-100%);
   transition: transform 200ms ease;
   z-index: 1000; /* über der Karte */
   font: 14px/1.5 system-ui, Arial, sans-serif;
 }
-.sidebar.hidden { transform: translateX(100%); }
+.sidebar.hidden { transform: translateX(-100%); }
 .sidebar.open   { transform: translateX(0%); }
 
 #sidebarClose {
@@ -72,7 +96,7 @@ html, body { margin:0; padding:0; height:100%; }
 }
 .place-item:hover { background: #f0f0f0; }
 
-/* Popup links von der Sidebar für Ortsdetails */
+/* Popup rechts von der Sidebar für Ortsdetails */
 .place-popup {
   position: fixed;
   max-width: 240px;
@@ -94,16 +118,16 @@ html, body { margin:0; padding:0; height:100%; }
   height: 0;
 }
 .place-popup::before {
-  right: -13px;
+  left: -13px;
   border-top: 9px solid transparent;
   border-bottom: 9px solid transparent;
-  border-left: 13px solid #ddd;
+  border-right: 13px solid #ddd;
 }
 .place-popup::after {
-  right: -12px;
+  left: -12px;
   border-top: 8px solid transparent;
   border-bottom: 8px solid transparent;
-  border-left: 12px solid #fff;
+  border-right: 12px solid #fff;
 }
 .place-popup.hidden {
   display: none;

--- a/index.html
+++ b/index.html
@@ -13,14 +13,18 @@
   />
   <!-- Dein Stylesheet -->
   <link rel="stylesheet" href="css/style.css?v=3" />
-</head>
-<body>
-  <div id="map"></div>
-  
-  <!-- Seitenleiste für lange Beschreibungen -->
-<div id="sidebar" class="sidebar hidden">
-  <button id="sidebarClose" aria-label="Schließen">×</button>
-  <div id="sidebarContent"></div>
+  </head>
+  <body>
+    <header id="titleBanner">
+      <img id="cityIcon" alt="Stadtwappen" />
+      <span class="title-text">Marle – Karte</span>
+    </header>
+    <div id="map"></div>
+
+    <!-- Seitenleiste für lange Beschreibungen -->
+  <div id="sidebar" class="sidebar hidden">
+    <button id="sidebarClose" aria-label="Schließen">×</button>
+    <div id="sidebarContent"></div>
   <div id="placesContainer" class="places-container">
     <div id="placeList" class="place-list"></div>
   </div>

--- a/js/script.js
+++ b/js/script.js
@@ -98,7 +98,7 @@ function openSidebar(props) {
           const itemRect = item.getBoundingClientRect();
           const sidebarRect = sidebar.getBoundingClientRect();
           placePopup.style.top = (itemRect.top + itemRect.height / 2) + 'px';
-          placePopup.style.right = (window.innerWidth - sidebarRect.left + 10) + 'px';
+          placePopup.style.left = (sidebarRect.right + 10) + 'px';
           placePopup.classList.remove('hidden');
         }
       });


### PR DESCRIPTION
## Summary
- Shift information sidebar to the left side and adjust popup positioning
- Add header banner with optional background image and city crest icon
- Update popups to render on right of new sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a4c618cc833080be3cb562a64220