### PR TITLE
feat: allow images and icons in sidebar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,4 @@
 # marle-map
+
+Interaktive Karte. Die rechte Sidebar kann optional ein Wappen (`icon`) und ein Landschaftsbild (`image`) aus den GeoJSON-Properties anzeigen.
+

--- a/css/style.css
+++ b/css/style.css
@@ -38,6 +38,19 @@ html, body { margin:0; padding:0; height:100%; }
 #sidebar p  { margin: 6px 0; }
 .sidebar .meta { color:#555; font-size: 13px; }
 
+.sidebar .nation-icon {
+  display: block;
+  max-width: 80px;
+  margin: 0 auto 12px;
+}
+
+.sidebar .nation-image {
+  width: 100%;
+  display: block;
+  margin: 8px 0;
+  border-radius: 4px;
+}
+
 .popup-actions {
   margin-top: 8px; display: flex; gap: 8px; flex-wrap: wrap;
 }

--- a/data/nations/01.geojson
+++ b/data/nations/01.geojson
@@ -7,6 +7,8 @@
         "name": "Valmorra",
         "desc": "Kurzbeschreibung …",
         "long": "Längere Beschreibung (optional, erscheint in der Sidebar).",
+        "icon": "https://placehold.co/80x80",
+        "image": "https://placehold.co/300x150",
         "places": [
           { "name": "Hauptstadt", "short": "Zentrum der Nation", "long": "Ausführliche Beschreibung der Hauptstadt." },
           { "name": "Nordhafen", "short": "Wichtiger Handelshafen", "long": "Mehr Details zum Nordhafen." },

--- a/js/script.js
+++ b/js/script.js
@@ -74,9 +74,13 @@ function openSidebar(props) {
   const name = props?.name ?? 'Unbenannte Nation';
   const descLong = props?.long ?? props?.desc ?? '';
   const places = Array.isArray(props?.places) ? props.places : [];
+  const icon = props?.icon ?? '';
+  const image = props?.image ?? '';
 
   sidebarContent.innerHTML = `
+    ${icon ? `<img class="nation-icon" src="${icon}" alt="Wappen von ${name}">` : ''}
     <h2>${name}</h2>
+    ${image ? `<img class="nation-image" src="${image}" alt="Landschaft von ${name}">` : ''}
     ${descLong ? `<div class="long">${descLong}</div>` : '<p><i>Keine längere Beschreibung gespeichert.</i></p>'}
   `;
 


### PR DESCRIPTION
## Summary
- enable optional `icon` and `image` properties to show coat of arms and landscape photos in the right sidebar
- style sidebar images via new CSS classes
- demonstrate usage with sample GeoJSON entry

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5a5010260833080e2016c2f6e3da2