### PR TITLE
Separate sidebars for nations and places

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -33,27 +33,39 @@ html, body { margin:0; padding:0; height:100%; }
 }
 .map-reset:hover { background:#f3f3f3; }
 
-/* Seitenleiste links */
+/* Seitenleisten (links für Orte, rechts für Nationen) */
 .sidebar {
   position: fixed;
   top: 0;
-  left: 0;
   width: 360px;
   max-width: 90vw;
   height: 100vh;
   background: #ffffff;
-  box-shadow: 4px 0 18px rgba(0,0,0,.15);
   padding: 16px 14px 24px;
   overflow: auto;
-  transform: translateX(-100%);
   transition: transform 200ms ease;
   z-index: 1000; /* über der Karte */
   font: 14px/1.5 system-ui, Arial, sans-serif;
 }
-.sidebar.hidden { transform: translateX(-100%); }
-.sidebar.open   { transform: translateX(0%); }
 
-#sidebarClose {
+.sidebar-left {
+  left: 0;
+  box-shadow: 4px 0 18px rgba(0,0,0,.15);
+  transform: translateX(-100%);
+}
+.sidebar-right {
+  right: 0;
+  box-shadow: -4px 0 18px rgba(0,0,0,.15);
+  transform: translateX(100%);
+}
+
+.sidebar-left.hidden  { transform: translateX(-100%); }
+.sidebar-left.open    { transform: translateX(0); }
+.sidebar-right.hidden { transform: translateX(100%); }
+.sidebar-right.open   { transform: translateX(0); }
+
+#sidebarClose,
+#placesClose {
   position: sticky; top: 0; float: right;
   border: 0; background: #eee; width: 32px; height: 32px; border-radius: 6px;
   font-size: 20px; cursor: pointer;
@@ -90,12 +102,9 @@ html, body { margin:0; padding:0; height:100%; }
 }
 
 /* Liste wichtiger Orte in der Sidebar */
-#placesContainer {
+#placeList {
   margin-top: 16px;
   font: 14px/1.4 system-ui, Arial, sans-serif;
-}
-
-#placeList {
   max-height: 180px;
   overflow-y: auto;
   background: #fff;

--- a/index.html
+++ b/index.html
@@ -22,13 +22,16 @@
     <div id="map"></div>
 
     <!-- Seitenleiste für lange Beschreibungen -->
-  <div id="sidebar" class="sidebar hidden">
-    <button id="sidebarClose" aria-label="Schließen">×</button>
-    <div id="sidebarContent"></div>
-  <div id="placesContainer" class="places-container">
-    <div id="placeList" class="place-list"></div>
-  </div>
-</div>
+    <div id="sidebar" class="sidebar sidebar-right hidden">
+      <button id="sidebarClose" aria-label="Schließen">×</button>
+      <div id="sidebarContent"></div>
+    </div>
+
+    <!-- Seitenleiste für wichtige Orte -->
+    <div id="placesSidebar" class="sidebar sidebar-left hidden">
+      <button id="placesClose" aria-label="Schließen">×</button>
+      <div id="placeList" class="place-list"></div>
+    </div>
 
   <div id="placePopup" class="place-popup hidden"></div>
 

--- a/js/script.js
+++ b/js/script.js
@@ -69,14 +69,15 @@ const nationsLayer = L.geoJSON([], {
 }).addTo(map);
 
 // Sidebar-Referenzen nur einmal holen
-const sidebar = document.getElementById('sidebar');
+const sidebar = document.getElementById('sidebar'); // rechte Sidebar
 const sidebarContent = document.getElementById('sidebarContent');
 const sidebarClose = document.getElementById('sidebarClose');
-const placesContainer = document.getElementById('placesContainer');
+const placesSidebar = document.getElementById('placesSidebar'); // linke Sidebar
 const placeList = document.getElementById('placeList');
+const placesClose = document.getElementById('placesClose');
 const placePopup = document.getElementById('placePopup');
 
-placesContainer?.addEventListener('click', ev => ev.stopPropagation());
+placesSidebar?.addEventListener('click', ev => ev.stopPropagation());
 placePopup?.addEventListener('click', ev => ev.stopPropagation());
 document.addEventListener('click', () => {
   placePopup?.classList.add('hidden');
@@ -98,9 +99,16 @@ function openSidebar(props) {
 
   placePopup?.classList.add('hidden');
 
-  if (placesContainer && placeList) {
+  if (placesSidebar && placeList) {
     placeList.innerHTML = '';
-    placesContainer.style.display = places.length ? '' : 'none';
+
+    if (places.length) {
+      placesSidebar.classList.remove('hidden');
+      placesSidebar.classList.add('open');
+    } else {
+      placesSidebar.classList.remove('open');
+      placesSidebar.classList.add('hidden');
+    }
 
     places.forEach(p => {
       const item = document.createElement('div');
@@ -129,7 +137,14 @@ function openSidebar(props) {
 sidebarClose?.addEventListener('click', () => {
   sidebar.classList.remove('open');
   sidebar.classList.add('hidden');
+  placesSidebar?.classList.remove('open');
+  placesSidebar?.classList.add('hidden');
   placePopup?.classList.add('hidden');
+});
+
+placesClose?.addEventListener('click', () => {
+  placesSidebar?.classList.remove('open');
+  placesSidebar?.classList.add('hidden');
 });
 
 // Helper: lädt eine Datei (GeoJSON)


### PR DESCRIPTION
## Summary
- Show nation descriptions in right sidebar and move place list into new left sidebar
- Update styling to support both left and right sidebars
- Adjust script logic to populate and control the new places sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b6c45ea0833087c0ed4a94d78f68