### PR TITLE
Style nation sidebar and make place list collapsible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -74,10 +74,22 @@ html, body { margin:0; padding:0; height:100%; }
 #sidebar p  { margin: 6px 0; }
 .sidebar .meta { color:#555; font-size: 13px; }
 
-.sidebar .nation-icon {
-  display: block;
-  max-width: 80px;
-  margin: 0 auto 12px;
+.nation-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.nation-header h2 {
+  margin: 0;
+  flex: 1;
+  font-size: 18px;
+}
+.nation-header .nation-icon {
+  width: 48px;
+  height: 48px;
+  object-fit: contain;
+  margin: 0;
 }
 
 .sidebar .nation-image {
@@ -114,9 +126,21 @@ html, body { margin:0; padding:0; height:100%; }
 .place-item {
   padding: 8px 10px;
   border-bottom: 1px solid #ddd;
-  cursor: pointer;
 }
-.place-item:hover { background: #f0f0f0; }
+.place-item .place-name {
+  cursor: pointer;
+  font-weight: 600;
+}
+.place-item .place-desc {
+  display: none;
+  margin-top: 4px;
+  font-size: 13px;
+  color: #333;
+}
+.place-item.open .place-desc {
+  display: block;
+}
+.place-item .place-name:hover { background: #f0f0f0; }
 
 /* Popup rechts von der Sidebar für Ortsdetails */
 .place-popup {

--- a/js/script.js
+++ b/js/script.js
@@ -91,8 +91,10 @@ function openSidebar(props) {
   const image = props?.image ?? '';
 
   sidebarContent.innerHTML = `
-    ${icon ? `<img class="nation-icon" src="${icon}" alt="Wappen von ${name}">` : ''}
-    <h2>${name}</h2>
+    <div class="nation-header">
+      <h2>${name}</h2>
+      ${icon ? `<img class="nation-icon" src="${icon}" alt="Wappen von ${name}">` : ''}
+    </div>
     ${image ? `<img class="nation-image" src="${image}" alt="Landschaft von ${name}">` : ''}
     ${descLong ? `<div class="long">${descLong}</div>` : '<p><i>Keine längere Beschreibung gespeichert.</i></p>'}
   `;
@@ -113,18 +115,30 @@ function openSidebar(props) {
     places.forEach(p => {
       const item = document.createElement('div');
       item.className = 'place-item';
-      item.textContent = p.name;
-      item.title = p.short ?? '';
-      item.addEventListener('click', ev => {
-         ev.stopPropagation();
-           placePopup?.classList.add('hidden');
 
-           const marker = p.__marker;
-             if (marker) {
-             const targetZoom = Math.max(map.getZoom(), placesMinZoom);
-             map.once('moveend', () => marker.openPopup());
-           map.setView(marker.getLatLng(), targetZoom);
-           }
+      const nameDiv = document.createElement('div');
+      nameDiv.className = 'place-name';
+      nameDiv.textContent = p.name;
+      item.appendChild(nameDiv);
+
+      if (p.short) {
+        const descDiv = document.createElement('div');
+        descDiv.className = 'place-desc';
+        descDiv.textContent = p.short;
+        item.appendChild(descDiv);
+      }
+
+      nameDiv.addEventListener('click', ev => {
+        ev.stopPropagation();
+        item.classList.toggle('open');
+        placePopup?.classList.add('hidden');
+
+        const marker = p.__marker;
+        if (marker) {
+          const targetZoom = Math.max(map.getZoom(), placesMinZoom);
+          map.once('moveend', () => marker.openPopup());
+          map.setView(marker.getLatLng(), targetZoom);
+        }
       });
 
       placeList.appendChild(item);


### PR DESCRIPTION
## Summary
- Display nation name alongside its crest in sidebar header and show landscape below
- Allow important places list to expand for short descriptions and collapse on name click

## Testing
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e98d32388330b9c3ed27807d183b