### PR TITLE
Kommentare für Sidebar-Schritte ergänzt

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -89,7 +89,7 @@ function openSidebar(props) {
   const places = Array.isArray(props?.places) ? props.places : [];
   const icon = props?.icon ?? '';
   const image = props?.image ?? '';
-
+  // Inhalt zusammenstellen
   sidebarContent.innerHTML = `
     <div class="nation-header">
       <h2>${name}</h2>
@@ -102,6 +102,7 @@ function openSidebar(props) {
   placePopup?.classList.add('hidden');
 
   if (placesSidebar && placeList) {
+    // Orte-Liste aufbauen
     placeList.innerHTML = '';
 
     if (places.length) {
@@ -128,6 +129,7 @@ function openSidebar(props) {
         item.appendChild(descDiv);
       }
 
+      // Events binden
       nameDiv.addEventListener('click', ev => {
         ev.stopPropagation();
         item.classList.toggle('open');
@@ -142,21 +144,25 @@ function openSidebar(props) {
       });
 
       placeList.appendChild(item);
-    });
-  }
+      });
+    }
 
   sidebar.classList.remove('hidden');
   sidebar.classList.add('open');
-}
+  }
 sidebarClose?.addEventListener('click', () => {
+  // rechte Sidebar ausblenden
   sidebar.classList.remove('open');
   sidebar.classList.add('hidden');
+  // linke Sidebar ausblenden
   placesSidebar?.classList.remove('open');
   placesSidebar?.classList.add('hidden');
+  // Popup ausblenden
   placePopup?.classList.add('hidden');
 });
 
 placesClose?.addEventListener('click', () => {
+  // linke Sidebar ausblenden
   placesSidebar?.classList.remove('open');
   placesSidebar?.classList.add('hidden');
 });


### PR DESCRIPTION
## Summary
- Kommentierende Zeilen für Inhaltsaufbau, Orte-Liste und Event-Bindungen in `openSidebar`
- Close-Handler dokumentieren nun, welche Bereiche verborgen werden

## Testing
- `npm test` *(fehlschlag: package.json fehlt)*

------
https://chatgpt.com/codex/tasks/task_e_68b71ed1d5448330aedfa22a602ba30d