### PR TITLE
Adjust wiki popup positioning for viewport boundaries

### DIFF
--- a/js/wiki.js
+++ b/js/wiki.js
@@ -4,8 +4,15 @@
 
   function position(win, link) {
     const rect = link.getBoundingClientRect();
-    win.style.left = rect.right + window.scrollX + 8 + 'px';
-    win.style.top = rect.top + window.scrollY + 'px';
+    const width = win.offsetWidth;
+    let left = rect.right + window.scrollX + 8;
+    if (left + width > window.scrollX + window.innerWidth) {
+      left = rect.left + window.scrollX - width - 8;
+    }
+    let top = rect.top + window.scrollY;
+    top = Math.min(top, window.scrollY + window.innerHeight - win.offsetHeight);
+    win.style.left = left + 'px';
+    win.style.top = top + 'px';
   }
 
   function initLink(link) {


### PR DESCRIPTION
## Summary
- compute popup width after insertion and adjust horizontal placement to avoid overflowing the viewport
- clamp vertical position so the popup stays fully visible within the window

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8488fc64c8330a28f152ae9a1b04d