### PR TITLE
Fix wiki preview timeout, query cache parameter, and sanitize sidebar

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -108,8 +108,19 @@ function openSidebar(props) {
       ${icon ? `<img class="nation-icon" src="${icon}" alt="Wappen von ${name}">` : ''}
     </div>
     ${image ? `<img class="nation-image" src="${image}" alt="Landschaft von ${name}">` : ''}
-    ${descLong ? `<div class="long">${descLong}</div>` : '<p><i>Keine längere Beschreibung gespeichert.</i></p>'}
   `;
+  if (descLong) {
+    const longDiv = document.createElement('div');
+    longDiv.className = 'long';
+    longDiv.textContent = descLong;
+    sidebarContent.appendChild(longDiv);
+  } else {
+    const p = document.createElement('p');
+    const i = document.createElement('i');
+    i.textContent = 'Keine längere Beschreibung gespeichert.';
+    p.appendChild(i);
+    sidebarContent.appendChild(p);
+  }
 
   placePopup?.classList.add('hidden');
 
@@ -181,7 +192,11 @@ placesClose?.addEventListener('click', () => {
 
 // ===== Abschnitt 4: Daten laden =====
 // Helper: lädt eine Datei (GeoJSON)
-const loadOne = (url) => fetch(url + '?v=' + Date.now()).then(r => r.json());
+const loadOne = (url) => {
+  const u = new URL(url, location.href);
+  u.searchParams.set('v', Date.now());
+  return fetch(u).then(r => r.json());
+};
 
 // Haupt-Ladefunktion: erkennt automatisch, ob index.json (mit "files") oder direktes GeoJSON
 loadOne(CFG.data.nationsUrl)

--- a/js/wiki.js
+++ b/js/wiki.js
@@ -77,7 +77,7 @@
           openWindows.push(win);
           if (!rootWindow) rootWindow = win;
         }
-      }, LOC
+      }, LOCK_DELAY);
     });
 
     // Zeiger verlässt den Link → Fenster schließen, falls nicht fixiert


### PR DESCRIPTION
## Summary
- correct wiki preview timeout constant usage
- handle existing URL parameters when cache busting JSON requests
- sanitize long descriptions in sidebar to prevent XSS

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b84d4873e88330aae1e17ef0e04157