### PR TITLE
Fix wiki tooltip staying open

### DIFF
--- a/js/wiki.js
+++ b/js/wiki.js
@@ -2,8 +2,6 @@
 (function() {
   // Liste aller dauerhaft geöffneten Wiki-Fenster
   const openWindows = [];
-  // Merkt sich das erste fixierte Fenster als "Wurzel"
-  let rootWindow = null;
   const LOCK_DELAY = 2500;
 
   /**
@@ -75,7 +73,6 @@
         }
         if (win) {
           openWindows.push(win);
-          if (!rootWindow) rootWindow = win;
         }
       }, LOCK_DELAY);
     });
@@ -102,14 +99,7 @@
 
   document.addEventListener('click', (e) => {
     if (e.target.closest('.wiki-window') || e.target.closest('[data-wiki]')) return;
-    openWindows.forEach(w => {
-      if (w !== rootWindow) w.remove();
-    });
-    if (rootWindow) {
-      openWindows.length = 1;
-      openWindows[0] = rootWindow;
-    } else {
-      openWindows.length = 0;
-    }
+    openWindows.forEach(w => w.remove());
+    openWindows.length = 0;
   });
 })();


### PR DESCRIPTION
## Summary
- Remove logic that kept the first wiki tooltip permanently open
- Close all wiki tooltips when clicking outside

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8526f14dc8330a847a0f6086545d4